### PR TITLE
Include Magenta A11y in the accessibility tools

### DIFF
--- a/Accessibility/accessibility_tools.md
+++ b/Accessibility/accessibility_tools.md
@@ -6,6 +6,8 @@
 
 * [Dubbot](https://princeton.dubbot.com/)
 
+* [MagentaA11y](https://www.magentaa11y.com/)
+
 #### General accessibility checkers
 
 * [Axe-devtools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US)


### PR DESCRIPTION
Provides accessibility acceptance criteria across Web and Native