### PR TITLE
Remove libapps from the list

### DIFF
--- a/.github/ISSUE_TEMPLATE/weekly_deployments.md
+++ b/.github/ISSUE_TEMPLATE/weekly_deployments.md
@@ -50,10 +50,6 @@ assignees: ''
 - [ ] Staging
 - [ ] Production
 
-#### LibApps
-- [ ] Staging
-- [ ] Production
-
 #### PUL_Assets
 - [ ] Staging
 - [ ] Production


### PR DESCRIPTION
these are templates for the springshare websites