### PR TITLE
Rename bibdata-staging.princeton.edu to bibdata-staging.lib.princeton.edu

### DIFF
--- a/.github/ISSUE_TEMPLATE/workcycle_build_and_deploy.md
+++ b/.github/ISSUE_TEMPLATE/workcycle_build_and_deploy.md
@@ -23,7 +23,7 @@ assignees: ''
   - [ ] Playbook
   - [ ] Deploy
 #### Bibdata
-- [ ] [Staging](https://bibdata-staging.princeton.edu/)
+- [ ] [Staging](https://bibdata-staging.lib.princeton.edu/)
   - [ ] Playbook
   - [ ] Deploy
 - [ ] [QA](https://bibdata-qa.princeton.edu/)


### PR DESCRIPTION
Rename bibdata-staging.princeton.edu to bibdata-staging.lib.princeton.edu
Bibdata staging is on adc-dev and using the .lib