### PR TITLE
Remove Drupal DACS playbook instruction

### DIFF
--- a/maintenance.md
+++ b/maintenance.md
@@ -7,5 +7,4 @@ title: Maintenance
 * To run all the DACS playbooks: `ansible-playbook playbooks/dacs_playbooks.yml -e runtime_env=staging`
 * To run all the Rails DACS playbooks: `ansible-playbook playbooks/dacs_playbooks.yml -e runtime_env=staging -t rails`
 * To run all the PHP DACS playbooks (including Drupal): `ansible-playbook playbooks/dacs_playbooks.yml -e runtime_env=staging -t php`
-* To run all the Drupal DACS playbooks: `ansible-playbook playbooks/dacs_playbooks.yml -e runtime_env=staging -t drupal`
 * To run all the Vue DACS playbooks: `ansible-playbook playbooks/dacs_playbooks.yml -e runtime_env=staging -t vue`


### PR DESCRIPTION
We no longer have any drupal applications.